### PR TITLE
fix: `DocsAsideTree.vue` by clicking on the link from dialog

### DIFF
--- a/components/app/AppHeaderDialog.vue
+++ b/components/app/AppHeaderDialog.vue
@@ -53,7 +53,7 @@ watch(show, v => (v ? open() : close()))
           </div>
         </div>
 
-        <DocsAsideTree :links="links" />
+        <DocsAsideTree :links="links" @close-nav="show = false" />
       </div>
     </nav>
   </teleport>

--- a/components/docs/DocsAsideTree.vue
+++ b/components/docs/DocsAsideTree.vue
@@ -20,6 +20,8 @@ const props = defineProps({
   }
 })
 
+const emits = defineEmits(['closeNav'])
+
 const route = useRoute()
 const { config } = useDocus()
 
@@ -99,12 +101,12 @@ const hasNesting = computed(() => props.links.some((link: any) => link.children)
       <NuxtLink
         v-else
         :to="link.redirect ? link.redirect : link._path"
-        class="link"
         :exact="link.exact"
+        class="link"
         :class="{
           'padded': level > 0 || !hasNesting,
-          'active': isActive(link),
         }"
+        @click.native="emits('closeNav')"
       >
         <span class="content">
           <Icon
@@ -123,6 +125,7 @@ const hasNesting = computed(() => props.links.some((link: any) => link.children)
         :level="level + 1"
         :parent="link"
         :max="max"
+        @close-nav="emits('closeNav')"
         class="recursive"
       />
     </li>


### PR DESCRIPTION
### 📚  Description

When we access the site, for example, from mobile devices, we open the menu and select any of the links.
After this -> we will be redirected to the desired page BUT when we go to the page, our menu __does not__ close and it turns out that we need to __click outside__ it so that it disappears.

So, the problem is resolved in this pr ✅



