### PR TITLE
docs: fix erroneous labelling of code as preview

### DIFF
--- a/docs/content/3.essentials/3.components.md
+++ b/docs/content/3.essentials/3.components.md
@@ -187,7 +187,7 @@ Wrap your `card` components with the `card-group` component to group them togeth
     ::::
   :::
 
-  :::tabs-item{.my-5 icon="i-lucide-eye" label="Preview"}
+  :::tabs-item{.my-5 icon="i-lucide-code" label="Code"}
   ```mdc
   :::card-group
   


### PR DESCRIPTION
I found an example of both tabs being called "Preview" instead of one being "Code".

As the content had not, in fact, been duplicated, I simply corrected the label - amending both the text and the icon.