### PR TITLE
chore: get-started typo

### DIFF
--- a/docs/content/en/1.getting-started/6.migration.md
+++ b/docs/content/en/1.getting-started/6.migration.md
@@ -28,7 +28,7 @@ Your existing Markdown content and MDC syntax will work without changes. The mig
 
 Already using a Markdown-based solution for your documentation? Whether it’s **Docus v1**, the **Nuxt UI Pro docs template**, or another static site setup, migrating to Docus is simple and straightforward.
 
-Docus offers a clean and maintainable solution with a single dependency: the Docus library itself. There’s no need to manage multiple .dependencies With everything built-in and maintained together, keeping your documentation up to date is easier than ever.
+Docus offers a clean and maintainable solution with a single dependency: the Docus library itself. There’s no need to manage multiple dependencies. With everything built-in and maintained together, keeping your documentation up to date is easier than ever.
 
 To migrate, just move your existing Markdown files into the `content/` directory of the Docus starter.
 


### PR DESCRIPTION
Move the `.` where it belongs.