### PR TITLE
fix(i18n): update French documentation content and structure

### DIFF
--- a/.starters/i18n/content/fr/index.md
+++ b/.starters/i18n/content/fr/index.md
@@ -22,7 +22,10 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   trailing-icon: i-lucide-arrow-right
   ---
   Commencer
-@ -29,93 +31,234 @@ Docus rassemble le meilleur de l'écosystème Nuxt en une seule CLI.
+  :::
+
+  :::u-button
+  ---
   color: neutral
   icon: simple-icons-github
   size: xl
@@ -34,6 +37,10 @@ Docus intègre le meilleur de l'écosystème Nuxt.
 ::
 
 ::u-page-section
+#title
+Livré avec de nombreuses fonctionnalités
+
+#features
   :::u-page-feature
   ---
   icon: i-simple-icons-nuxt
@@ -42,7 +49,7 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   ---
   #title
   Construit avec [Nuxt 4]{.text-primary}
-  
+
   #description
   Optimisé par votre meta framework Vue préféré. Docus vous donne tout ce dont vous avez besoin pour créer des sites rapides, performants et optimisés pour le SEO.
   :::
@@ -55,7 +62,7 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   ---
   #title
   Propulsé par [Nuxt UI Pro]{.text-primary}
-  
+
   #description
   Sexy, minimaliste et personnalisable. Docus intègre Nuxt UI Pro pour vous offrir la meilleure expérience pour écrire une documentation sans boilerplate, concentrez-vous simplement sur votre contenu.
   :::
@@ -68,7 +75,7 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   ---
   #title
   Markdown amélioré par [Nuxt Content]{.text-primary}
-  
+
   #description
   La seule chose dont vous devez vous soucier est d'écrire votre contenu. Rédigez vos pages en Markdown et intégrer des composants Nuxt UI ou des composants Vue personnalisés. La structure, le routing et le rendu sont gérés pour vous.
   :::
@@ -81,7 +88,7 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   ---
   #title
   Personnalisation avec [Nuxt App Config]{.text-primary}
-  
+
   #description
   Mettez à jour les couleurs, les liens sociaux, les logos ou même le style de vos composants globalement via le `app.config.ts`, sans modification directe du code.
   :::
@@ -94,7 +101,7 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   ---
   #title
   Collaborez sur [Nuxt Studio]{.text-primary}
-  
+
   #description
   Rédigez et gérez votre contenu visuellement, sans aucune connaissance de Markdown requise. Laissez vos collègues non techniques collaborer sur la documentation et intégrer des composants Vue sans compétences en code.
   :::
@@ -107,8 +114,8 @@ Docus intègre le meilleur de l'écosystème Nuxt.
   ---
   #title
   Navigation intégrée et [recherche textuelle]{.text-primary}
-  
+
   #description
   Concentrez-vous uniquement sur votre contenu, Docus génère automatiquement une modale de recherche et la navigation latérale pour vous.
   :::
-:: 
+::


### PR DESCRIPTION
Fixed some bugs in the `.starters/i18n/content/fr/index.md` template. It contained text that prevented the buttons from displaying correctly.